### PR TITLE
Draw borders if colorinlistoftodos

### DIFF
--- a/todonotes.dtx
+++ b/todonotes.dtx
@@ -46,7 +46,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{570}
+% \CheckSum{571}
 %
 % \CharacterTable
 %  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -1568,7 +1568,8 @@
 \newcommand{\@todonotes@addElementToListOfTodos}{%
     \if@todonotes@colorinlistoftodos%
         \addcontentsline{tdo}{todo}{%
-            \colorbox{\@todonotes@currentbackgroundcolor}%
+            \fcolorbox{\@todonotes@currentbordercolor}%
+                {\@todonotes@currentbackgroundcolor}%
                 {\textcolor{\@todonotes@currentbackgroundcolor}{o}}%
             \ \@todonotes@caption}%
     \else%


### PR DESCRIPTION
A tiny modification to `\@todonotes@addElementToListOfTodos` to draw frames around the colour boxes in the TODO list, making them mimic the TODO notes more accurately, e.g. when using the same background colour (all white, in my personal case) and different border colours.
