### PR TITLE
remove duplicated drawing of notes

### DIFF
--- a/todonotes.dtx
+++ b/todonotes.dtx
@@ -47,7 +47,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{596}
+% \CheckSum{593}
 %
 % \CharacterTable
 %  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -1705,8 +1705,6 @@
     \hbadness 100000%
     \begin{tikzpicture}[remember picture,baseline=(X.base)]%
         \node(X){\vphantom{X}};%
-        \draw node[notestyle,font=\@todonotes@sizecommand,anchor=north] (inNote) at (X.north)%
-            {\@todonotes@text};%
         \if@todonotes@authorgiven%
             \draw node[notestyle,font=\@todonotes@sizecommand,anchor=north] (inNote) at (X.north)%
                 {\@todonotes@sizecommand\@todonotes@author};%


### PR DESCRIPTION
Hi, this PR fixes the problem of drawing notes two times. The problem is usually invisible due to the background color, but if backgroundcolor=none then it becomes clear that something is wrong.

Here is a minimal tex file that shows the problem:

```
\documentclass{article}
\usepackage[backgroundcolor=none]{todonotes}
\begin{document}
This text is not sharp. \todo{This text is sharp!}

Another paragraph:
\todo[author=Author]{Another todo}
\end{document}
```
