### PR TITLE
option to draw todo note in the text directly (no \par etc. added)

### DIFF
--- a/todonotes.dtx
+++ b/todonotes.dtx
@@ -1857,7 +1857,11 @@
 % \begin{macro}{\todo}
 % Define the |\todo| command as a redirection to |\@todo|.
 %    \begin{macrocode}
-\newcommand{\todo}[2][]{\@bsphack\@todo[#1]{#2}\@esphack\ignorespaces}%
+\newcommand{\todo}[2][]{\if@todonotes@inlinepar%
+  \@bsphack\@todo[#1]{#2}\@esphack\ignorespaces%
+  \else%
+  \@todo[#1]{#2}%
+  \fi}%
 %    \end{macrocode}
 % \end{macro}
 % \appendix

--- a/todonotes.dtx
+++ b/todonotes.dtx
@@ -1514,6 +1514,13 @@
 \define@key{todonotes}%
     {inlinewidth}{\renewcommand{\@todonotes@inlinewidth}{#1}}
 %    \end{macrocode}
+% Change if inline note is written to a separate line or not.
+%    \begin{macrocode}
+\newif\if@todonotes@inlinepar
+\@todonotes@inlinepartrue
+\define@key{todonotes}{inlinepar}[]{\@todonotes@inlinepartrue}%
+\define@key{todonotes}{noinlinepar}[]{\@todonotes@inlineparfalse}%
+%    \end{macrocode}
 % Preset values of the options
 %    \begin{macrocode}
 \presetkeys%
@@ -1530,7 +1537,8 @@
     figheight=\@todonotes@figheight,%
     figcolor=\@todonotes@figcolor,%
     line, list, size=\@todonotes@textsize,
-    inlinewidth=\linewidth}{}%
+    inlinewidth=\linewidth,
+    inlinepar}{}%
 %    \end{macrocode}
 % \subsection{The main code part}
 % Here is the actual macros defined.
@@ -1690,24 +1698,32 @@
 %    \begin{macrocode}
 \newcommand{\@todonotes@drawInlineNote}{%
     \if@todonotes@dviStyle%
-        {\par\noindent\begin{tikzpicture}[remember picture]%
-            \draw node[inlinenotestyle] {};\end{tikzpicture}\par}%
+        {\if@todonotes@inlinepar\par\noindent\fi%
+         \begin{tikzpicture}[remember picture]%
+            \draw node[inlinenotestyle] {};
+         \end{tikzpicture}%
+         \if@todonotes@inlinepar\par\fi}%
             \if@todonotes@authorgiven%
                 {\noindent \@todonotes@sizecommand \@todonotes@author:\,\@todonotes@text}%
             \else%
                 {\noindent \@todonotes@sizecommand \@todonotes@text}%
             \fi
-        {\par\noindent\begin{tikzpicture}[remember picture]%
-            \draw node[inlinenotestyle] {};\end{tikzpicture}\par}%
+        {\if@todonotes@inlinepar\par\noindent\fi%
+         \begin{tikzpicture}[remember picture]%
+            \draw node[inlinenotestyle] {};
+         \end{tikzpicture}%
+         \if@todonotes@inlinepar\par\fi}%
     \else%
-        {\par\noindent\begin{tikzpicture}[remember picture]%
+        {\if@todonotes@inlinepar\par\noindent\fi%
+         \begin{tikzpicture}[remember picture]%
             \draw node[inlinenotestyle,font=\@todonotes@sizecommand]{%
                 \if@todonotes@authorgiven%
                     {\noindent \@todonotes@sizecommand \@todonotes@author:\,\@todonotes@text}%
                 \else%
                     {\noindent \@todonotes@sizecommand \@todonotes@text}%
                 \fi};%
-            \end{tikzpicture}\par}%
+         \end{tikzpicture}%
+         \if@todonotes@inlinepar\par\fi}%
     \fi}%
 %    \end{macrocode}
 % \end{macro}

--- a/todonotes.dtx
+++ b/todonotes.dtx
@@ -1508,6 +1508,12 @@
 \define@key{todonotes}%
     {figcolor}{\renewcommand{\@todonotes@currentfigcolor}{#1}}
 %    \end{macrocode}
+% Change the width of an inline note.
+%    \begin{macrocode}
+\newcommand{\@todonotes@inlinewidth}{\linewidth}%
+\define@key{todonotes}%
+    {inlinewidth}{\renewcommand{\@todonotes@inlinewidth}{#1}}
+%    \end{macrocode}
 % Preset values of the options
 %    \begin{macrocode}
 \presetkeys%
@@ -1523,7 +1529,8 @@
     figwidth=\@todonotes@figwidth,%
     figheight=\@todonotes@figheight,%
     figcolor=\@todonotes@figcolor,%
-    line, list, size=\@todonotes@textsize}{}%
+    line, list, size=\@todonotes@textsize,
+    inlinewidth=\linewidth}{}%
 %    \end{macrocode}
 % \subsection{The main code part}
 % Here is the actual macros defined.
@@ -1571,7 +1578,7 @@
     draw=\@todonotes@currentlinecolor]
 \tikzstyle{inlinenotestyle} = [
     notestyle, 
-    text width=\linewidth - 1.6 ex - 1 pt]
+    text width=\@todonotes@inlinewidth - 1.6 ex - 1 pt]
 %    \end{macrocode}
 %
 % \begin{macro}{\@todo}


### PR DESCRIPTION
The new options `inlinepar`/`noinlinepar` allow to skip the new lines added before and after an inline todo note. This is useful together with using `inlinewidth` (#25), so that a todo-box can appear directly in the text, but does not use a separate line.

- `inlinepar`/`noinlinepar`: the naming of these parameters might need some adaption (suggestions?)
- at the moment, the box is aligned bottom to base line. One could add `baseline=(current bounding box.center)` to the tikz-options to somehow align centered, or the modified `baseline={([yshift=-.5ex]current bounding box.center)}`.