### PR TITLE
Turn warning about marginlength into a real warning (#29)

### DIFF
--- a/todonotes.dtx
+++ b/todonotes.dtx
@@ -1218,7 +1218,7 @@
 \newcommand{\phantomsection}{}
 \fi
 \ifdim \marginparwidth < 2cm 
-\todo[inline]{Warning. The length $\backslash$marginparwidth is 
+\PackageWarning{todonotes}{The length $\backslash$marginparwidth is 
 less than 2cm and will most likely cause issues with the 
 appearance of inserted todonotes. 
 The issue can be solved by adding a line like 


### PR DESCRIPTION
As I said, having warnings in the actual document is huge no-go. This prints the warning on the command line (and the log file) instead.