### PR TITLE
Fix todo in math mode.

### DIFF
--- a/todonotes.dtx
+++ b/todonotes.dtx
@@ -1986,13 +1986,13 @@ prior to loading the todonotes package.} \else\fi%
   \if@inlabel \leavevmode \fi     
   \if@noskipsec \leavevmode \fi
   \if@todonotes@inlinepar
-    \ifhmode
-      \@bsphack
-      \@todonotes@vmodefalse
-    \else
+    \ifvmode
       \@savsf\@m
       \@savsk\z@
       \@todonotes@vmodetrue
+    \else
+      \@bsphack
+      \@todonotes@vmodefalse
     \fi
     {\@todo[#1]{#2}}%
     \@esphack%


### PR DESCRIPTION
By using \\ifvmode instead of \\ifhmode and appropriately reversing the branches of the conditional, math mode is correctly detected as a non-vertical mode.