### PR TITLE
adding flexible formatting for notes

### DIFF
--- a/testsuite/formats.tex
+++ b/testsuite/formats.tex
@@ -1,0 +1,22 @@
+\documentclass{article}
+\usepackage[format=textbf]{todonotes}
+
+\begin{document}
+todonotes with format options.
+
+\listoftodos
+
+\missingfigure{Draw this figure \ldots}
+
+\todo{Testing: textbf as default}
+\todo[inline,author=XXX]{Testing inline: textbf}
+\todo[format=emph]{Testing: emph}
+\todo[inline,author=XXX]{Testing inline with author: textbf}
+\todo[author={XXX},caption={Caption},format=emph]{Testing: emph, with
+author and caption}
+\todo[author={XXX},caption={Caption},prepend,format=emph]{Testing: emph, with
+author and prepended caption}
+\renewcommand{\todoformat}[1]{[[\textsl{#1}]]}
+\todo{Testing: no option, back to default, but we've redefined
+\texttt{\textbackslash todoformat} }
+\end{document}

--- a/todonotes.dtx
+++ b/todonotes.dtx
@@ -1566,6 +1566,15 @@ prior to loading the todonotes package.} \else\fi%
 \define@key{todonotes.sty}%
     {textwidth}{\renewcommand{\@todonotes@textwidth}{#1}}
 %    \end{macrocode}
+% Make the formatting of a note an option. Notes are formatted using
+% |\todoformat|, which by default does nothing. If the option
+% |format=cmd| is given, notes are formatted using |\cmd| instead.
+% Default formatting can also be changed by redefining |\todoformat|
+%    \begin{macrocode}
+\newcommand{\todoformat}[1]{#1}
+\define@key{todonotes.sty}%
+    {format}{\renewcommand{\todoformat}{\@nameuse{#1}}}
+%    \end{macrocode}
 % Make the text size as an option, accept both |size| and |textsize|. 
 %    \begin{macrocode}
 \define@key{todonotes.sty}%
@@ -1657,6 +1666,14 @@ prior to loading the todonotes package.} \else\fi%
 %    \begin{macrocode}
 \define@key{todonotes}{tickmarkheight}{%
     \renewcommand{\@todonotes@tickmarkheight}{#1}}%
+%    \end{macrocode}
+% Make formatting of notes a per-note option as well, by redefining
+% the internal |\@todonotes@format| command, which is then used in
+% formatting the actual note.
+%    \begin{macrocode}
+\newcommand{\@todonotes@format}{\todoformat}%
+\define@key{todonotes}{format}{%
+    \renewcommand{\@todonotes@format}{\@nameuse{#1}}}%
 %    \end{macrocode}
 % Set a relative font size
 %    \begin{macrocode}
@@ -1753,6 +1770,7 @@ prior to loading the todonotes package.} \else\fi%
     backgroundcolor=\@todonotes@backgroundcolor,%
     textcolor=\@todonotes@textcolor,%
     bordercolor=\@todonotes@bordercolor,%
+    format=todoformat,
     tickmarkheight=\@todonotes@defaulttickmarkheight,%
     nofancyline,%
     nodisable,%
@@ -1964,9 +1982,10 @@ prior to loading the todonotes package.} \else\fi%
          \end{tikzpicture}%
          \if@todonotes@inlinepar\par\fi}%
             \if@todonotes@authorgiven%
-                {\noindent \@todonotes@useSizeCommand \@todonotes@author:\,\@todonotes@text}%
+                {\noindent \@todonotes@useSizeCommand \@todonotes@author:\,\@todonotes@format{\@todonotes@text}}%
             \else%
-                {\noindent \@todonotes@useSizeCommand \@todonotes@text}%
+                {\noindent \@todonotes@useSizeCommand 
+                    \@todonotes@format{\@todonotes@text}}%
             \fi
         {\if@todonotes@inlinepar\par\noindent\fi%
          \begin{tikzpicture}[remember picture]%
@@ -1978,9 +1997,10 @@ prior to loading the todonotes package.} \else\fi%
          \begin{tikzpicture}[remember picture]%
             \draw node[inlinenotestyle,font=\@todonotes@useSizeCommand]{%
                 \if@todonotes@authorgiven%
-                    {\noindent \@todonotes@author:\,\@todonotes@text}%
+                    {\noindent \@todonotes@author:\,%
+                        \@todonotes@format{\@todonotes@text}}%
                 \else%
-                    {\noindent \@todonotes@text}%
+                    {\noindent \@todonotes@format{\@todonotes@text}}%
                 \fi};%
          \end{tikzpicture}%
          \if@todonotes@inlinepar\par\fi}%
@@ -1997,9 +2017,10 @@ prior to loading the todonotes package.} \else\fi%
     \end{tikzpicture}\\%
     \begin{minipage}{\@todonotes@textwidth}%
     \if@todonotes@authorgiven%
-      \@todonotes@useSizeCommand \@todonotes@author \@todonotes@text%
+      \@todonotes@useSizeCommand \@todonotes@author:\,
+         \@todonotes@format{\@todonotes@text}%
     \else%
-      \@todonotes@useSizeCommand \@todonotes@text%
+      \@todonotes@useSizeCommand\@todonotes@format{\@todonotes@text}%
     \fi%
     \end{minipage}\\%
     \begin{tikzpicture}[remember picture]%
@@ -2015,10 +2036,10 @@ prior to loading the todonotes package.} \else\fi%
                 {\@todonotes@author};%
             \node(Y)[below=of X]{};%
             \draw node[notestyle,font=\@todonotes@useSizeCommand,anchor=north] (inNote) at (X.south)%
-                {\@todonotes@text};%
+                {\@todonotes@format{\@todonotes@text}};%
         \else%
             \draw node[notestyle,font=\@todonotes@useSizeCommand,anchor=north] (inNote) at (X.north)%
-                {\@todonotes@text};%
+                {\@todonotes@format{\@todonotes@text}};%
         \fi%
     \end{tikzpicture}%
     \hbadness \originalHbadness%


### PR DESCRIPTION
I took a first stab at the other idea: formatting the notes using a command (by default `\todoformat`) which can be set by giving an option. Unlike the `size` option this does only take the name of the command, not the command itself, so eg `\todo[format=textbf]{Stuff}` but not `\todo[format=textbf]{Stuff}`. If you like it I can add the same idea for formatting the author and for the note in the LoN.